### PR TITLE
Post release 1.4.0: Update version to 1.4.0.dev0

### DIFF
--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -6,6 +6,7 @@ on:
       version:
         description: 'Version number (e.g., 1.0.1)'
         required: true
+  push:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
@@ -27,8 +28,8 @@ jobs:
 
       - name: Extract Major.Minor Version and setup Env variable
         run: |
-          echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
-          echo "MAJOR_MINOR=$(echo ${{ github.event.inputs.version }} | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')" >> $GITHUB_ENV
+          echo "VERSION=1.4.0" >> $GITHUB_ENV
+          echo "MAJOR_MINOR=$(echo 1.4.0 | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')" >> $GITHUB_ENV
 
       - name: Get current major.minor version from main branch
         id: get_version
@@ -84,8 +85,8 @@ jobs:
 
       - name: Extract Major.Minor Version and setup Env variable
         run: |
-          echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
-          echo "MAJOR_MINOR=$(echo ${{ github.event.inputs.version }} | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')" >> $GITHUB_ENV
+          echo "VERSION=1.4.0" >> $GITHUB_ENV
+          echo "MAJOR_MINOR=$(echo 1.4.0 | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')" >> $GITHUB_ENV
 
       - name: Determine release branch and checkout
         run: |
@@ -96,12 +97,45 @@ jobs:
       - name: Update version to next development version in main
         # TODO update version in daily_scan.yml
         run: |
-          DEV_VERSION="${{ github.event.inputs.version }}.dev0"
+          DEV_VERSION="1.4.0.dev0"
           sed -i "s/public static string version = \".*\";/public static string version = \"${DEV_VERSION}\";/" src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Version.cs
           sed -i "s/private readonly string version = \".*\";/private readonly string version = \"${DEV_VERSION}\";/" build/Build.InstallationScripts.cs
-          VERSION="${{ github.event.inputs.version }}"
+          VERSION="1.4.0"
           git add src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Version.cs
           git add build/Build.InstallationScripts.cs
+
+      - name: Append latest release checksum to release-build-metadata.json
+        run: |
+          ARTIFACT_NAMES=(
+            "aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip"
+            "aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip"
+            "aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip"
+            "aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip"
+            "aws-distro-opentelemetry-dotnet-instrumentation-windows.zip"
+            "aws-otel-dotnet-install.sh"
+            "AWS.Otel.DotNet.Auto.psm1"
+          )
+
+          FILE="release-build-metadata.json"
+          UPDATED_JSON=$(jq --arg version "1.4.0" \
+                  '.release[0].version = $version' "$FILE")
+          echo "$UPDATED_JSON" > "$FILE"
+
+          BASE_URL="https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.4.0"
+          for ARTIFACT_NAME in "${ARTIFACT_NAMES[@]}"; do
+            curl -L -o "$ARTIFACT_NAME" "${BASE_URL}/${ARTIFACT_NAME}"
+            CHECKSUM=$(shasum -a 256 $ARTIFACT_NAME | awk '{ print $1 }')
+
+            UPDATED_JSON=$(jq --arg name "$ARTIFACT_NAME" \
+                              --arg checksum "$CHECKSUM" \
+                              '.release[0].checksum += [{"name": $name, "checksum": $checksum}]' "$FILE")
+            echo "$UPDATED_JSON" > "$FILE"
+          done
+
+          git add release-build-metadata.json
+
+      - name: Push changes to Github
+        run: |
           git commit -m "Prepare main for next development cycle: Update version to $DEV_VERSION"
           git push --set-upstream origin "prepare-main-for-next-dev-cycle-${VERSION}"
 
@@ -109,7 +143,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ env.BOT_TOKEN_GITHUB_RW_PATOKEN }}
         run: |
-          DEV_VERSION="${{ github.event.inputs.version }}.dev0"
+          DEV_VERSION="1.4.0.dev0"
           gh pr create --title "Post release $VERSION: Update version to $DEV_VERSION" \
                        --body "This PR prepares the main branch for the next development cycle by updating the version to $DEV_VERSION and updating the image version to be scanned to the latest released.
 

--- a/build/Build.InstallationScripts.cs
+++ b/build/Build.InstallationScripts.cs
@@ -8,7 +8,7 @@ using Nuke.Common.IO;
 internal partial class Build : NukeBuild
 {
     private readonly AbsolutePath installationScriptsFolder = RootDirectory / "bin" / "InstallationScripts";
-    private readonly string version = "1.3.2.dev0";
+    private readonly string version = "1.4.0.dev0";
 
     public Target BuildInstallationScripts => _ => _
         .After(this.Clean)

--- a/release-build-metadata.json
+++ b/release-build-metadata.json
@@ -1,0 +1,37 @@
+{
+    "release": [
+        {
+            "version": "1.4.0",
+            "checksum": [
+                {
+                    "name": "aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip",
+                    "checksum": "eb8528483cd2174ecdba997c5e8ad9cca29e7b925d4d940a5bd998182343827d"
+                },
+                {
+                    "name": "aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip",
+                    "checksum": "f793e834e6eb9f4e2f40b3c7879aeb01270e83e75144a397e0ae26bdd5c0d8b5"
+                },
+                {
+                    "name": "aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip",
+                    "checksum": "064c42e3592a00db9dc952ee3d70da0c3d3fea02ca7a559030958ee84e1c46dd"
+                },
+                {
+                    "name": "aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip",
+                    "checksum": "fe0af95949f5839135c93c549816a535c50204d6e9625e7fc9dcabd4b627a529"
+                },
+                {
+                    "name": "aws-distro-opentelemetry-dotnet-instrumentation-windows.zip",
+                    "checksum": "ff5207bc59115b7dd62b9b462b334453414271f804998206954c94ff707c9827"
+                },
+                {
+                    "name": "aws-otel-dotnet-install.sh",
+                    "checksum": "b49dded80b2c25ccf99745b557af1143672b50621c2259b3a117503f2bdcbcef"
+                },
+                {
+                    "name": "AWS.Otel.DotNet.Auto.psm1",
+                    "checksum": "521c065a66424fc76e41a4d1ff62a2f2cfe850b4632f0726fb9ddf0419598b49"
+                }
+            ]
+        }
+    ]
+}

--- a/release-build-metadata.json
+++ b/release-build-metadata.json
@@ -1,37 +1,70 @@
 {
-    "release": [
+  "release": [
+    {
+      "version": "1.4.0",
+      "checksum": [
         {
-            "version": "1.4.0",
-            "checksum": [
-                {
-                    "name": "aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip",
-                    "checksum": "eb8528483cd2174ecdba997c5e8ad9cca29e7b925d4d940a5bd998182343827d"
-                },
-                {
-                    "name": "aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip",
-                    "checksum": "f793e834e6eb9f4e2f40b3c7879aeb01270e83e75144a397e0ae26bdd5c0d8b5"
-                },
-                {
-                    "name": "aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip",
-                    "checksum": "064c42e3592a00db9dc952ee3d70da0c3d3fea02ca7a559030958ee84e1c46dd"
-                },
-                {
-                    "name": "aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip",
-                    "checksum": "fe0af95949f5839135c93c549816a535c50204d6e9625e7fc9dcabd4b627a529"
-                },
-                {
-                    "name": "aws-distro-opentelemetry-dotnet-instrumentation-windows.zip",
-                    "checksum": "ff5207bc59115b7dd62b9b462b334453414271f804998206954c94ff707c9827"
-                },
-                {
-                    "name": "aws-otel-dotnet-install.sh",
-                    "checksum": "b49dded80b2c25ccf99745b557af1143672b50621c2259b3a117503f2bdcbcef"
-                },
-                {
-                    "name": "AWS.Otel.DotNet.Auto.psm1",
-                    "checksum": "521c065a66424fc76e41a4d1ff62a2f2cfe850b4632f0726fb9ddf0419598b49"
-                }
-            ]
+          "name": "aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip",
+          "checksum": "eb8528483cd2174ecdba997c5e8ad9cca29e7b925d4d940a5bd998182343827d"
+        },
+        {
+          "name": "aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip",
+          "checksum": "f793e834e6eb9f4e2f40b3c7879aeb01270e83e75144a397e0ae26bdd5c0d8b5"
+        },
+        {
+          "name": "aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip",
+          "checksum": "064c42e3592a00db9dc952ee3d70da0c3d3fea02ca7a559030958ee84e1c46dd"
+        },
+        {
+          "name": "aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip",
+          "checksum": "fe0af95949f5839135c93c549816a535c50204d6e9625e7fc9dcabd4b627a529"
+        },
+        {
+          "name": "aws-distro-opentelemetry-dotnet-instrumentation-windows.zip",
+          "checksum": "ff5207bc59115b7dd62b9b462b334453414271f804998206954c94ff707c9827"
+        },
+        {
+          "name": "aws-otel-dotnet-install.sh",
+          "checksum": "b49dded80b2c25ccf99745b557af1143672b50621c2259b3a117503f2bdcbcef"
+        },
+        {
+          "name": "AWS.Otel.DotNet.Auto.psm1",
+          "checksum": "521c065a66424fc76e41a4d1ff62a2f2cfe850b4632f0726fb9ddf0419598b49"
         }
-    ]
+      ]
+    },
+    {
+      "version": "",
+      "checksum": [
+        {
+          "name": "aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip",
+          "checksum": "eb8528483cd2174ecdba997c5e8ad9cca29e7b925d4d940a5bd998182343827d"
+        },
+        {
+          "name": "aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip",
+          "checksum": "f793e834e6eb9f4e2f40b3c7879aeb01270e83e75144a397e0ae26bdd5c0d8b5"
+        },
+        {
+          "name": "aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip",
+          "checksum": "064c42e3592a00db9dc952ee3d70da0c3d3fea02ca7a559030958ee84e1c46dd"
+        },
+        {
+          "name": "aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip",
+          "checksum": "fe0af95949f5839135c93c549816a535c50204d6e9625e7fc9dcabd4b627a529"
+        },
+        {
+          "name": "aws-distro-opentelemetry-dotnet-instrumentation-windows.zip",
+          "checksum": "ff5207bc59115b7dd62b9b462b334453414271f804998206954c94ff707c9827"
+        },
+        {
+          "name": "aws-otel-dotnet-install.sh",
+          "checksum": "b49dded80b2c25ccf99745b557af1143672b50621c2259b3a117503f2bdcbcef"
+        },
+        {
+          "name": "AWS.Otel.DotNet.Auto.psm1",
+          "checksum": "521c065a66424fc76e41a4d1ff62a2f2cfe850b4632f0726fb9ddf0419598b49"
+        }
+      ]
+    }
+  ]
 }

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Version.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Version.cs
@@ -5,5 +5,5 @@ namespace AWS.Distro.OpenTelemetry.AutoInstrumentation;
 
 static class Version
 {
-    public static string version = "1.3.2.dev0";
+    public static string version = "1.4.0.dev0";
 }


### PR DESCRIPTION
This PR prepares the main branch for the next development cycle by updating the version to 1.4.0.dev0 and updating the image version to be scanned to the latest released.

This PR should only be merge when release for version v1.4.0 is success.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.